### PR TITLE
Change sed syntax because of errors; add IPv6 NAT

### DIFF
--- a/seed-server/Dockerfile
+++ b/seed-server/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM alpine:3.16.2 as builder
 
-RUN apk add --update bash openvpn bc iptables && \
+RUN apk add --update bash openvpn bc iptables ip6tables && \
     rm -rf /var/cache/apk/*
 
 WORKDIR /volume
@@ -81,8 +81,9 @@ RUN mkdir -p ./bin ./sbin ./lib ./usr/bin ./usr/sbin ./usr/lib ./usr/lib/xtables
     && cp -d /usr/lib/libip6* ./usr/lib                                     && echo "package iptables" \
     && cp -d /usr/lib/libipq* ./usr/lib                                     && echo "package iptables" \
     && cp -d /usr/lib/libxtables* ./usr/lib                                 && echo "package iptables" \
-    && cp -d /usr/lib/xtables/* ./usr/lib/xtables                           && echo "package iptables"
-
+    && cp -d /usr/lib/xtables/* ./usr/lib/xtables                           && echo "package iptables" \
+    && cp -d /sbin/ip6tables* ./sbin                                        && echo "package ip6tables"
+    
 FROM scratch
 
 COPY --from=builder /volume /

--- a/seed-server/network-connection.sh
+++ b/seed-server/network-connection.sh
@@ -36,12 +36,12 @@ pod_network="${pod_network:-100.96.0.0/11}"
 node_network="${NODE_NETWORK:-${fileNodeNetwork}}"
 node_network="${node_network:-}"
 
-sed -e "s/\${SERVICE_NETWORK}/${service_network}/" \
-    -e "s/\${POD_NETWORK}/${pod_network}/" \
+sed -e "s#\${SERVICE_NETWORK}#${service_network}#" \
+    -e "s#\${POD_NETWORK}#${pod_network}#" \
     openvpn.config.template > openvpn.config
 
-sed -e "s/\${SERVICE_NETWORK}/${service_network}/" \
-    -e "s/\${POD_NETWORK}/${pod_network}/" \
+sed -e "s#\${SERVICE_NETWORK}#${service_network}#" \
+    -e "s#\${POD_NETWORK}#${pod_network}#" \
     /client-config-dir/vpn-shoot-client.template > /client-config-dir/vpn-shoot-client
 
 if [[ ! -z "$node_network" ]]; then
@@ -52,7 +52,9 @@ if [[ ! -z "$node_network" ]]; then
     done
 fi
 
+echo 1 > /proc/sys/net/ipv6/conf/all/forwarding
+
 local_node_ip="${LOCAL_NODE_IP:-255.255.255.255}"
 
 # filter log output to remove readiness/liveness probes from local node
-openvpn --config openvpn.config | grep -v -E "TCP connection established with \[AF_INET\]${local_node_ip}|${local_node_ip}:[0-9]{1,5} Connection reset, restarting"
+openvpn --config openvpn.config | grep -v -E "TCP connection established with \[AF_INET6\]${local_node_ip}|${local_node_ip}:[0-9]{1,5} Connection reset, restarting"

--- a/shoot-client/Dockerfile
+++ b/shoot-client/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM alpine:3.16.2 as builder
 
-RUN apk add --update bash openvpn iptables bc && \
+RUN apk add --update bash openvpn iptables ip6tables bc && \
     rm -rf /var/cache/apk/*
 
 WORKDIR /volume
@@ -78,7 +78,8 @@ RUN mkdir -p ./bin ./sbin ./lib ./usr/bin ./usr/sbin ./usr/lib ./usr/lib/xtables
     && cp -d /usr/lib/libip6* ./usr/lib                                     && echo "package iptables" \
     && cp -d /usr/lib/libipq* ./usr/lib                                     && echo "package iptables" \
     && cp -d /usr/lib/libxtables* ./usr/lib                                 && echo "package iptables" \
-    && cp -d /usr/lib/xtables/* ./usr/lib/xtables                           && echo "package iptables"
+    && cp -d /usr/lib/xtables/* ./usr/lib/xtables                           && echo "package iptables" \
+    && cp -d /sbin/ip6tables* ./sbin                                        && echo "package ip6tables"
 
 FROM scratch
 

--- a/shoot-client/network-connection.sh
+++ b/shoot-client/network-connection.sh
@@ -73,8 +73,8 @@ node_network="${node_network:-}"
 
 reversed_vpn_header="${REVERSED_VPN_HEADER:-invalid-host}"
 
-sed -e "s/\${SERVICE_NETWORK}/${service_network}/" \
-    -e "s/\${POD_NETWORK}/${pod_network}/" \
+sed -e "s#\${SERVICE_NETWORK}#${service_network}#" \
+    -e "s#\${POD_NETWORK}#${pod_network}#" \
     openvpn.config.template > openvpn.config
 
 if [[ ! -z "$node_network" ]]; then
@@ -90,9 +90,10 @@ echo "pull-filter ignore redirect-gateway" >> openvpn.config
 echo "pull-filter ignore route-ipv6" >> openvpn.config
 echo "pull-filter ignore redirect-gateway-ipv6" >> openvpn.config
 
+
 # enable forwarding and NAT
-iptables --append FORWARD --in-interface tun0 -j ACCEPT
-iptables --append POSTROUTING --out-interface eth0 --table nat -j MASQUERADE
+echo 1 > /proc/sys/net/ipv6/conf/all/forwarding
+ip6tables --append POSTROUTING --out-interface eth0 --table nat -j MASQUERADE
 
 while : ; do
     if [[ ! -z $ENDPOINT ]]; then


### PR DESCRIPTION
Changes sed syntax because I got errors, should be the same logic as before!
Added ip6tables to set IPv6 NAT rule, also enabled IPv6 forwarding. 

Works in local setup as worked on here: https://github.com/gardener/gardener/pull/6755

Images available at docker.io:
docker.io/einfachnuralex/vpn-seed-server:0.12.0-dev7
docker.io/einfachnuralex/vpn-shoot-client:0.12.0-dev7